### PR TITLE
A small bug fix where a waxed hoglin trophy was all opaque

### DIFF
--- a/src/main/java/com/soytutta/mynethersdelight/client/MyNethersDelightClient.java
+++ b/src/main/java/com/soytutta/mynethersdelight/client/MyNethersDelightClient.java
@@ -38,5 +38,6 @@ public class MyNethersDelightClient implements ClientModInitializer {
         instance.putBlock(MNDBlocks.WARPED_FUNGUS_COLONY.get(), RenderType.cutout());
         instance.putBlock(MNDBlocks.WALL_POWDERY_TORCH.get(), RenderType.cutout());
         instance.putBlock(MNDBlocks.ZOGLIN_TROPHY.get(), RenderType.cutout());
+        instance.putBlock(MNDBlocks.WAXED_HOGLIN_TROPHY.get(), RenderType.cutout());
     }
 }


### PR DESCRIPTION
I noticed in the game that the waxed hoglin trophy had black texture spots instead of transparent ones, how it is in non-waxed variant, and fixed it.